### PR TITLE
Update spell.js

### DIFF
--- a/js/app/model/spell.js
+++ b/js/app/model/spell.js
@@ -1362,19 +1362,17 @@ define(['can'], function(can) {
         },
         fheal_disc_atonement: function(delta) {
             return(
-                //Patch 5.3: Atonement now heals nearby friendly targets for 90% of the damage dealt, down from 100%.  
-                //Also, there does not appear to be any triple-dipping into the crit effect meta.  
-                //The combined critical heal + Divine Aegis from atonement is base heal + base heal *  mastery % 
-                //from character screen.  The crit meta gem is completely ignored!  The updated calculation was 
-                //tested against combat logs and appears accurate.
-                0.9 * this.fbase(delta) * 
+                //Patch 5.3: Atonement now heals nearby friendly targets for 90% of the damage dealt, down from 100%.
+                //Also, there does not appear to be any triple-dipping into the crit effect meta - the effect is triggered once
+                0.9 * this.fbase(delta) *
                 (
-                    (1 - this.spec.fcritp(delta)) + 
-                        (1 + 
+                    (1 - this.spec.fcritp(delta)) +
+                        (1 +
                             (1 + 2 * this.spec.fmastp(delta))
-                        ) * 
-                    this.spec.fcritp(delta)
-                )             
+                        ) *
+                    this.spec.fcritp(delta) 
+                    * (this.spec.critmeta? 1.03 : 1)
+                )
             );
         },
         fheal_spirit_shell: function(delta) {


### PR DESCRIPTION
1.  Accounted for Patch 5.3 Glyph of Smite change: Glyph of Smite no longer causes the additional 20% damage dealt by Smite to transfer into Atonement.
2.  Updated for Patch 5.3 Atonement nerfs: Atonement now heals nearby friendly targets for 90% of the damage dealt, down from 100%.
3.  Fixed Atonement average heal calculation.  There does not appear to be any triple-dipping into the crit effect meta.  The combined critical heal from Atonement is base heal + base heal \*  mastery % from character screen.  A key revelation is that the crit meta gem is completely ignored for Atonement!  The updated calculation was tested against combat logs and appears accurate.

I verified the updated calculations by approaching a target dummy and smiting away, clearing any Evangelism/trinket/Jade Spirit etc. effects after every cast.  I only had Holy Fire active (no food or raid buffs).  For example, if a Smite crit healed me for 16021 (Atonement heals the caster for 50%), it would pop a Divine Aegis for 19463.  My mastery percentage from the character screen is 21.49%, and 16021 \* 1.2149 = 19463.9, which is very close to the result from my combat logs.  I suspect that Blizzard's approach to rounding might account for the minor difference.

My crit percentage from the character screen is 19.28%, respectively, yielding a calculation of 
16021_((1-0.1928)+(1+(1.2149))_0.1928) = 19773.64241 for the average heal.
1.  Accommodated Penance changes for Patch 5.3: Penance now deals 10% less damage, but healing done is increased by 10%.
